### PR TITLE
Pin whisperx for torch compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 runpod==1.7.12
-whisperx==3.3.4
+whisperx==3.3.1
 huggingface_hub==0.33.0
 setuptools-rust>=1.7.0
 python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- use whisperx v3.3.1 so requirements don't force torch>=2.5

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b1072645c833395550481f2733591